### PR TITLE
fix: add correct answer feedback if no player answers

### DIFF
--- a/kusogaki_bot/features/guess_the_anime/cog.py
+++ b/kusogaki_bot/features/guess_the_anime/cog.py
@@ -448,6 +448,9 @@ class GTAQuizCog(BaseCog):
 
                     game = self.service.get_game(channel_id)
                     current_round_difficulty = self.service.get_current_difficulty(game)
+                    game.round_feedback.append(
+                        f'The correct answer was: **{correct_answer}**'
+                    )
 
                     logger.info(f'Round started - Channel: {channel_id}')
                     logger.info(f'Correct answer is: {correct_answer}')
@@ -553,11 +556,6 @@ class GTAQuizCog(BaseCog):
                 )
                 game_state.answered_players.remove(interaction.user.id)
                 return
-
-            if not game_state.round_feedback:
-                game_state.round_feedback.append(
-                    f'The correct answer was: **{correct_answer}**'
-                )
 
             game_state.processing_answers = True
 


### PR DESCRIPTION
## What type of pull request is this? (check all applicable)

- [x] 🐛 Bug Fix
- [ ] 🤖 Build
- [ ] 🧑‍💻 Code Refactor
- [ ] 📦 Chore
- [ ] 🔁 CI
- [ ] 📝 Documentation
- [ ] ✨ Feature
- [ ] 🔥 Performance Improvements
- [ ] ⏩ Revert
- [ ] 🎨 Style
- [ ] ✅ Test

## Describe your changes

Changed correct answer feedback to be appended to round feedback variable always at the start of round instead of during a player's answer. Fixes a bug in GTA quiz resulting in an empty message being sent if none of the players answer.

## Describe what you did to test your changes

Ran games with no players answering, and multiple combinations of players answering/timing out

## What are the related issues?

N/A

## Contributor Checklist

- [x] Review [Contributing Guidelines](https://github.com/kusogaki-events/kusogaki-bot/blob/main/docs/CONTRIBUTING.md)
- [x] Commit messages should be prefixed with one of the commit types described in the contributing guidelines
- [x] Update documentation related to your changes(if applicable)
- [x] Ensure CI builds pass
- [x] Smoke testing in preview environment should be done prior to code review

## Reviewer Checklist

- [ ] Ensure all code changes match our current code style and conventions
- [ ] Ensure CI builds passed
- [ ] Ensure all changes are operating as expected in the preview environment