### PR TITLE
fix: wait until a user is eliminated to show high score

### DIFF
--- a/kusogaki_bot/features/guess_the_anime/data.py
+++ b/kusogaki_bot/features/guess_the_anime/data.py
@@ -57,6 +57,7 @@ class PlayerState:
     name: str
     lives: int = 3
     score: int = 0
+    pending_high_score: Optional[int] = None
 
 
 @dataclass

--- a/kusogaki_bot/features/guess_the_anime/service.py
+++ b/kusogaki_bot/features/guess_the_anime/service.py
@@ -402,10 +402,10 @@ class GTAGameService:
                         f'Got HARD correct. Totals - Easy: {game.easy_correct}, Medium: {game.medium_correct}, Hard: {game.hard_correct}'
                     )
 
-                new_high_score = self.repository.update_player_score(
+                player.pending_high_score = self.repository.update_player_score(
                     player_id, player.name, player.score
                 )
-                return True, False, new_high_score
+                return True, False, None
             else:
                 if player_id not in game.timed_out_players:
                     player.lives -= 1


### PR DESCRIPTION
The user getting feedback that they've gotten a new high score every time they answer is annoying and clouds the UI. Fixing this to only happen when they're eliminated

## What type of pull request is this? (check all applicable)

- [x] 🐛 Bug Fix
- [ ] 🤖 Build
- [ ] 🧑‍💻 Code Refactor
- [ ] 📦 Chore
- [ ] 🔁 CI
- [ ] 📝 Documentation
- [ ] ✨ Feature
- [ ] 🔥 Performance Improvements
- [ ] ⏩ Revert
- [ ] 🎨 Style
- [ ] ✅ Test

## Describe your changes

_Clearly and concisely describe what's in this pull request. Include screenshots, if necessary._

## Describe what you did to test your changes

_Clearly and concisely describe what you did to test your changes. Include screenshots, if necessary._

## What are the related issues?

_replace this text with relevant issues_

## Contributor Checklist

- [ ] Review [Contributing Guidelines](https://github.com/kusogaki-events/kusogaki-bot/blob/main/docs/CONTRIBUTING.md)
- [ ] Commit messages should be prefixed with one of the commit types described in the contributing guidelines
- [ ] Update documentation related to your changes(if applicable)
- [ ] Ensure CI builds pass
- [ ] Smoke testing in preview environment should be done prior to code review

## Reviewer Checklist

- [ ] Ensure all code changes match our current code style and conventions
- [ ] Ensure CI builds passed
- [ ] Ensure all changes are operating as expected in the preview environment