### PR TITLE
fix: filter out duplicate titles in GTA options

### DIFF
--- a/kusogaki_bot/features/guess_the_anime/service.py
+++ b/kusogaki_bot/features/guess_the_anime/service.py
@@ -335,9 +335,12 @@ class GTAGameService:
                 logger.error(f'Failed to load image from {image.link}')
                 return None, [], ''
 
-            options = random.sample(
-                wrong_options, min(self.MAX_OPTIONS - 1, len(wrong_options))
-            )
+            filtered_wrong_options = [
+                opt for opt in wrong_options if opt != image.anime_name
+            ]
+            num_wrong_options = min(self.MAX_OPTIONS - 1, len(filtered_wrong_options))
+            options = random.sample(filtered_wrong_options, num_wrong_options)
+
             options.append(image.anime_name)
             random.shuffle(options)
 


### PR DESCRIPTION
The correct answer is appended after sampling the wrong options, but there wasn't a check to ensure that the anime title wasn't already in the wrong options. There are multiple ways this could happen, but filtering them should solve the issue

## What type of pull request is this? (check all applicable)

- [x] 🐛 Bug Fix
- [ ] 🤖 Build
- [ ] 🧑‍💻 Code Refactor
- [ ] 📦 Chore
- [ ] 🔁 CI
- [ ] 📝 Documentation
- [ ] ✨ Feature
- [ ] 🔥 Performance Improvements
- [ ] ⏩ Revert
- [ ] 🎨 Style
- [ ] ✅ Test

## Describe your changes

_Clearly and concisely describe what's in this pull request. Include screenshots, if necessary._

## Describe what you did to test your changes

_Clearly and concisely describe what you did to test your changes. Include screenshots, if necessary._

## What are the related issues?

_replace this text with relevant issues_

## Contributor Checklist

- [ ] Review [Contributing Guidelines](https://github.com/kusogaki-events/kusogaki-bot/blob/main/docs/CONTRIBUTING.md)
- [ ] Commit messages should be prefixed with one of the commit types described in the contributing guidelines
- [ ] Update documentation related to your changes(if applicable)
- [ ] Ensure CI builds pass
- [ ] Smoke testing in preview environment should be done prior to code review

## Reviewer Checklist

- [ ] Ensure all code changes match our current code style and conventions
- [ ] Ensure CI builds passed
- [ ] Ensure all changes are operating as expected in the preview environment