### PR TITLE
fix: prevent duplicate incorrect options in gtaquiz

### DIFF
--- a/kusogaki_bot/features/guess_the_anime/service.py
+++ b/kusogaki_bot/features/guess_the_anime/service.py
@@ -336,7 +336,7 @@ class GTAGameService:
                 return None, [], ''
 
             filtered_wrong_options = [
-                opt for opt in wrong_options if opt != image.anime_name
+                opt for opt in dict.fromkeys(wrong_options) if opt != image.anime_name
             ]
             num_wrong_options = min(self.MAX_OPTIONS - 1, len(filtered_wrong_options))
             options = random.sample(filtered_wrong_options, num_wrong_options)


### PR DESCRIPTION
## What type of pull request is this? (check all applicable)

- [x] 🐛 Bug Fix
- [ ] 🤖 Build
- [ ] 🧑‍💻 Code Refactor
- [ ] 📦 Chore
- [ ] 🔁 CI
- [ ] 📝 Documentation
- [ ] ✨ Feature
- [ ] 🔥 Performance Improvements
- [ ] ⏩ Revert
- [ ] 🎨 Style
- [ ] ✅ Test

## Describe your changes

Fixes bug that would cause duplicate choices in GTA quiz questions.

## Describe what you did to test your changes

Ran test bot games and did not see any duplicates.

## What are the related issues?

N/A

## Contributor Checklist

- [x] Review [Contributing Guidelines](https://github.com/kusogaki-events/kusogaki-bot/blob/main/docs/CONTRIBUTING.md)
- [x] Commit messages should be prefixed with one of the commit types described in the contributing guidelines
- [x] Update documentation related to your changes(if applicable)
- [x] Ensure CI builds pass
- [x] Smoke testing in preview environment should be done prior to code review

## Reviewer Checklist

- [ ] Ensure all code changes match our current code style and conventions
- [ ] Ensure CI builds passed
- [ ] Ensure all changes are operating as expected in the preview environment