### PR TITLE
feat: join GTA quiz with button instead of message

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Refer to [CONTRIBUTING.md](https://github.com/kusogaki-events/kusogaki-bot/blob/
 ### GTA Quiz Game Commands
 Base command: `gtaquiz` (alias: `gq`)
 * `kuso gtaquiz start [difficulty]`: Start a new game session. If difficulty is specified (easy/medium/hard), only images of that difficulty will appear. Leave it unspecified to experience progressive difficulty similar to GTA's adaptive system on AniList
-* `kuso gtaquiz join`: Join an ongoing game before it starts
 * `kuso gtaquiz stop`: Stop the current game
 * `kuso gtaquiz leaderboard`: View global rankings
 * `kuso gtaquiz score`: Check your stats

--- a/kusogaki_bot/features/guess_the_anime/cog.py
+++ b/kusogaki_bot/features/guess_the_anime/cog.py
@@ -444,7 +444,7 @@ class GTAQuizCog(BaseCog):
                         f'Game starting in `{countdown}` seconds!\n'
                         f'{progress_bar}\n'
                         f'Starting player: {message.embeds[0].description.split("Starting player: ")[1].split("\n")[0]}\n\n'
-                        'Type `kuso gq join` to join!'
+                        'Press the button to join!'
                     ),
                 )
 

--- a/kusogaki_bot/features/guess_the_anime/cog.py
+++ b/kusogaki_bot/features/guess_the_anime/cog.py
@@ -310,7 +310,10 @@ class GTAQuizCog(BaseCog):
             result = self.service.add_player(
                 interaction.channel.id, interaction.user.id, interaction.user.name
             )
-            await interaction.response.send_message(result.message, ephemeral=True)
+            if result.success:
+                await interaction.response.send_message(result.message)
+            else:
+                await interaction.response.send_message(result.message, ephemeral=True)
 
         except Exception as e:
             logger.error(f'Error joining game: {e}')

--- a/kusogaki_bot/features/guess_the_anime/cog.py
+++ b/kusogaki_bot/features/guess_the_anime/cog.py
@@ -264,7 +264,7 @@ class GTAQuizCog(BaseCog):
                 EmbedType.NORMAL,
                 '🎮 Guess The Anime Quiz',
                 f'{result.message}\n'
-                f'Player(s): {', '.join(player_names)}\n\n'
+                f'Player(s): {", ".join(player_names)}\n\n'
                 'Press the button to join!',
             )
 
@@ -452,7 +452,7 @@ class GTAQuizCog(BaseCog):
                     description=(
                         f'Game starting in `{countdown}` seconds!\n'
                         f'{progress_bar}\n'
-                        f'Player(s): {', '.join(player_names)}\n\n'
+                        f'Player(s): {", ".join(player_names)}\n\n'
                         'Press the button to join!'
                     ),
                 )

--- a/kusogaki_bot/features/guess_the_anime/cog.py
+++ b/kusogaki_bot/features/guess_the_anime/cog.py
@@ -107,6 +107,75 @@ class AnswerView(discord.ui.View):
         return button_callback
 
 
+class JoinView(discord.ui.View):
+    """
+    A Discord UI View for handling the join button in the Guess The Anime quiz game.
+
+    Attributes:
+        cog (GTAQuizCog): The cog instance that owns this view
+    """
+
+    def __init__(self, cog: 'GTAQuizCog') -> None:
+        """
+        Initialize the view with a join button.
+
+        Args:
+            cog (GTAQuizCog): The cog instance that owns this view
+        """
+        super().__init__(timeout=None)
+        self.cog = cog
+
+        button = discord.ui.Button(
+            label='Join',
+            style=discord.ButtonStyle.primary,
+            custom_id='join',
+            row=0,
+        )
+        button.callback = self.make_callback()
+        self.add_item(button)
+
+    def make_callback(
+        self,
+    ) -> Callable[[discord.Interaction], Awaitable[None]]:
+        """
+        Create a callback function for the join button.
+
+        Returns:
+            Callable: Async callback function that handles button interactions
+        """
+
+        async def button_callback(interaction: discord.Interaction):
+            try:
+                game_state = self.cog.service.get_game(interaction.channel.id)
+                if not game_state:
+                    await interaction.response.send_message(
+                        'No active game found!', ephemeral=True
+                    )
+                    return
+
+                await self.cog.join_game(interaction=interaction)
+
+            except Exception as e:
+                logger.error(f'Error in button callback: {e}', exc_info=True)
+                if game_state:
+                    try:
+                        game_state.answered_players.remove(interaction.user.id)
+                    except KeyError:
+                        pass
+                try:
+                    await interaction.response.send_message(
+                        'Something went wrong joining the game. Please try again.',
+                        ephemeral=True,
+                    )
+                except discord.errors.InteractionResponded:
+                    await interaction.followup.send(
+                        'Something went wrong joining the game. Please try again.',
+                        ephemeral=True,
+                    )
+
+        return button_callback
+
+
 class GTAQuizCog(BaseCog):
     """
     Cog for the Guess The Anime quiz game. Handles all game-related commands and interactions.
@@ -188,15 +257,17 @@ class GTAQuizCog(BaseCog):
                 await ctx.send(result.message)
                 return
 
+            view = JoinView(self)
+
             embed, file = await self.create_embed(
                 EmbedType.NORMAL,
                 '🎮 Guess The Anime Quiz',
                 f'{result.message}\n'
                 f'Starting player: {ctx.author.mention}\n\n'
-                'Type `kuso gq join` to join!',
+                'Press the button to join!',
             )
 
-            msg = await ctx.send(embed=embed, file=file)
+            msg = await ctx.send(embed=embed, file=file, view=view)
 
             logger.info(f'Starting countdown for channel {ctx.channel.id}')
             task = asyncio.create_task(self._run_countdown(ctx.channel.id, msg))
@@ -223,8 +294,7 @@ class GTAQuizCog(BaseCog):
                 self.active_countdowns[ctx.channel.id].cancel()
                 del self.active_countdowns[ctx.channel.id]
 
-    @gta_quiz.command(name='join')
-    async def join_game(self, ctx: commands.Context) -> None:
+    async def join_game(self, interaction: discord.Interaction) -> None:
         """
         Join an ongoing game in the current channel.
 
@@ -238,12 +308,15 @@ class GTAQuizCog(BaseCog):
         """
         try:
             result = self.service.add_player(
-                ctx.channel.id, ctx.author.id, ctx.author.name
+                interaction.channel.id, interaction.user.id, interaction.user.name
             )
-            await ctx.send(result.message)
+            await interaction.response.send_message(result.message, ephemeral=True)
+
         except Exception as e:
             logger.error(f'Error joining game: {e}')
-            await ctx.send('An error occurred while joining the game.')
+            await interaction.response.send_message(
+                'An error occurred while joining the game.', ephemeral=True
+            )
 
     @gta_quiz.command(name='stop')
     async def stop_game(self, ctx: commands.Context) -> None:

--- a/kusogaki_bot/features/guess_the_anime/cog.py
+++ b/kusogaki_bot/features/guess_the_anime/cog.py
@@ -302,7 +302,7 @@ class GTAQuizCog(BaseCog):
         Players can only join during the countdown phase before the game starts.
 
         Args:
-            interaction (discord.Interaction): The interaction context
+            interaction (discord.Interaction): The button interaction triggering the join
 
         Raises:
             Exception: If there's an error adding the player to the game

--- a/kusogaki_bot/features/guess_the_anime/cog.py
+++ b/kusogaki_bot/features/guess_the_anime/cog.py
@@ -224,7 +224,7 @@ class GTAQuizCog(BaseCog):
         """
         if ctx.invoked_subcommand is None:
             await ctx.send(
-                'Available commands: `start`, `join`, `stop`, `leaderboard`, `score`'
+                'Available commands: `start`, `stop`, `leaderboard`, `score`'
             )
 
     @gta_quiz.command(name='start')

--- a/kusogaki_bot/features/guess_the_anime/cog.py
+++ b/kusogaki_bot/features/guess_the_anime/cog.py
@@ -157,11 +157,7 @@ class JoinView(discord.ui.View):
 
             except Exception as e:
                 logger.error(f'Error in button callback: {e}', exc_info=True)
-                if game_state:
-                    try:
-                        game_state.answered_players.remove(interaction.user.id)
-                    except KeyError:
-                        pass
+
                 try:
                     await interaction.response.send_message(
                         'Something went wrong joining the game. Please try again.',
@@ -259,11 +255,16 @@ class GTAQuizCog(BaseCog):
 
             view = JoinView(self)
 
+            player_names = (
+                f'<@{player_id}>'
+                for player_id in self.service.get_game(ctx.channel.id).players.keys()
+            )
+
             embed, file = await self.create_embed(
                 EmbedType.NORMAL,
                 '🎮 Guess The Anime Quiz',
                 f'{result.message}\n'
-                f'Starting player: {ctx.author.mention}\n\n'
+                f'Player(s): {', '.join(player_names)}\n\n'
                 'Press the button to join!',
             )
 
@@ -301,7 +302,7 @@ class GTAQuizCog(BaseCog):
         Players can only join during the countdown phase before the game starts.
 
         Args:
-            ctx (commands.Context): The command context
+            interaction (discord.Interaction): The interaction context
 
         Raises:
             Exception: If there's an error adding the player to the game
@@ -440,13 +441,18 @@ class GTAQuizCog(BaseCog):
                 filled = round((countdown / self.service.LOADING_TIME) * total_width)
                 progress_bar = f'`{"█" * filled}{"░" * (total_width - filled)}`'
 
+                player_names = (
+                    f'<@{player_id}>'
+                    for player_id in self.service.get_game(channel_id).players.keys()
+                )
+
                 embed, file = await self.create_embed(
                     type=EmbedType.NORMAL,
                     title='🎮 Guess The Anime Quiz',
                     description=(
                         f'Game starting in `{countdown}` seconds!\n'
                         f'{progress_bar}\n'
-                        f'Starting player: {message.embeds[0].description.split("Starting player: ")[1].split("\n")[0]}\n\n'
+                        f'Player(s): {', '.join(player_names)}\n\n'
                         'Press the button to join!'
                     ),
                 )

--- a/kusogaki_bot/features/help/service.py
+++ b/kusogaki_bot/features/help/service.py
@@ -30,7 +30,6 @@ The GTA Quiz Game allows users to participate in GTA style quiz using all the pr
 
 **Subcommands:**
 - `start [difficulty]` - Start a new game session. If difficulty is specified (easy/medium/hard), only images of that difficulty will appear. Leave it unspecified to experience progressive difficulty similar to GTA's adaptive system on AniList
-- `join` - Join an ongoing game before it starts
 - `stop` - Ends the current game session
 - `leaderboard` - Display global leaderboard with top players
 - `score` - Show your personal stats and rank
@@ -38,7 +37,6 @@ The GTA Quiz Game allows users to participate in GTA style quiz using all the pr
 **Examples:**
 ```
 kuso gtaquiz start
-kuso gtaquiz join
 kuso gq stop
 ```
 

--- a/kusogaki_bot/features/help/service.py
+++ b/kusogaki_bot/features/help/service.py
@@ -36,8 +36,9 @@ The GTA Quiz Game allows users to participate in GTA style quiz using all the pr
 
 **Examples:**
 ```
-kuso gtaquiz start
+kuso gtaquiz start medium
 kuso gq stop
+kuso gq leaderboard
 ```
 
 **Aliases:** `gq`


### PR DESCRIPTION
## What type of pull request is this? (check all applicable)

- [ ] 🐛 Bug Fix
- [ ] 🤖 Build
- [ ] 🧑‍💻 Code Refactor
- [ ] 📦 Chore
- [ ] 🔁 CI
- [ ] 📝 Documentation
- [x] ✨ Feature
- [ ] 🔥 Performance Improvements
- [ ] ⏩ Revert
- [ ] 🎨 Style
- [ ] ✅ Test

## Describe your changes

Add GTA quiz join button instead of joining by typing `kuso gq join`

## Describe what you did to test your changes

Played test games with multiple players.

## What are the related issues?

N/A

## Contributor Checklist

- [x] Review [Contributing Guidelines](https://github.com/kusogaki-events/kusogaki-bot/blob/main/docs/CONTRIBUTING.md)
- [x] Commit messages should be prefixed with one of the commit types described in the contributing guidelines
- [x] Update documentation related to your changes(if applicable)
- [x] Ensure CI builds pass
- [x] Smoke testing in preview environment should be done prior to code review

## Reviewer Checklist

- [ ] Ensure all code changes match our current code style and conventions
- [ ] Ensure CI builds passed
- [ ] Ensure all changes are operating as expected in the preview environment